### PR TITLE
Fix `zsh` not sourcing directly from NixOS configuration

### DIFF
--- a/common/configuration.nix
+++ b/common/configuration.nix
@@ -11,6 +11,7 @@ in
       ../modules/system/display-setup.nix
       ../modules/system/main-user.nix
       ../modules/system/network.nix
+      ../modules/system/shell.nix
       ../modules/system/ssh.nix
 
       # system packages

--- a/modules/home/zsh.nix
+++ b/modules/home/zsh.nix
@@ -33,12 +33,13 @@
     #   plugins = [ "git" "thefuck" ];
     #   theme = "robbyrussell";
     # };
+
+    # Explicitly write a .zshrc file to your home directory
+    initExtra = ''
+      # Add any additional configurations here
+      export ZSH_DISABLE_COMPFIX=true
+      export POWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD=true
+    '';
   };
 
-  # Explicitly write a .zshrc file to your home directory
-  home.file.".zshrc".text = ''
-    # Add any additional configurations here
-    export ZSH_DISABLE_COMPFIX=true
-    export POWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD=true
-  '';
 }

--- a/modules/home/zsh.nix
+++ b/modules/home/zsh.nix
@@ -5,6 +5,7 @@
     enable = true;
     enableCompletion = true;
     syntaxHighlighting.enable = true;
+    dotDir = ".config/zsh";
 
     shellAliases = {
       diff = "delta";

--- a/modules/system/main-user.nix
+++ b/modules/system/main-user.nix
@@ -1,4 +1,4 @@
-{ lib, config, ... }:
+{ lib, config, pkgs, ... }:
 
 let
   cfg = config.main-user;
@@ -33,6 +33,7 @@ in
         "wheel"  # wheel: enable `sudo` for the user
       ];
       hashedPasswordFile = cfg.hashedPasswordFile;
+      shell = pkgs.zsh;
     };
   };
 }

--- a/modules/system/shell.nix
+++ b/modules/system/shell.nix
@@ -1,0 +1,5 @@
+{ ... }:
+
+{
+  programs.zsh.enable = true;
+}


### PR DESCRIPTION
- **Replace `home.file.".zshrc".text` with `initExtra`**
- **Make `zsh` source from NixOS configuration**
